### PR TITLE
install_arch: Fix permissions for root

### DIFF
--- a/roles/install_arch/tasks/main.yml
+++ b/roles/install_arch/tasks/main.yml
@@ -51,9 +51,6 @@
   unarchive:
     src: /tmp/archlinux-bootstrap-{{ bootstrap_version }}-x86_64.tar.gz
     dest: /tmp
-    owner: root
-    group: root
-    mode: 0644
     remote_src: yes
     creates: /tmp/root.x86_64
 


### PR DESCRIPTION
When extracting the bootstrap image, do not set owner, group and mode
anymore. Those compeltly screwed up permission of the chroot environment
making it unstartable (because executables are not executable).